### PR TITLE
fix: normal chromosome copy number could be 0

### DIFF
--- a/src/cnv_tools/__init__.py
+++ b/src/cnv_tools/__init__.py
@@ -6,7 +6,7 @@ cnv_tools
 cnv_tools is a collection of tools for analysis of genome copy number data.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 from cnv_tools.cnv import Cnv
 from cnv_tools.copy_number import (

--- a/src/cnv_tools/manhattan_plot.py
+++ b/src/cnv_tools/manhattan_plot.py
@@ -158,9 +158,9 @@ class ManhattanPlot:
             integer_copy_number : int
                 The integer copy number. The result will only be 1 or 2.
             """
-            supported_chr_copy_numbers: list[int] = [1, 2]
-            max_chr_copy_number: int = int(max(supported_chr_copy_numbers))
-            min_chr_copy_number: int = int(min(supported_chr_copy_numbers))
+            supported_normal_chr_copy_numbers: list[int] = [0, 1, 2]
+            max_chr_copy_number: int = int(max(supported_normal_chr_copy_numbers))
+            min_chr_copy_number: int = int(min(supported_normal_chr_copy_numbers))
             copy_number_series: pl.Series = pl.Series(copy_numbers)
             copy_number_series_lower_quantile: float = copy_number_series.quantile(
                 quantile=0.25, interpolation="lower"


### PR DESCRIPTION
Some times the copy number data contains chromosome Y but the sex is female, so the copy number will be 0.